### PR TITLE
Fix plugin name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Slack JIRA Plugin
+# Slack Alias Plugin
 
 A Slack plugin for expanding aliases to actual people  
 


### PR DESCRIPTION
The README says "Slack JIRA Plugin" instead of Slack Alias Plugin
