### PR TITLE
Fix #4

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -34,7 +34,7 @@ Bot.prototype.run = function () {
   var self = this,
       verbose = self.config.verbose,
       bot = new slackbot(this.config.token),
-      pattern = "(?:@)((";
+      pattern = "^(?!>).*(?:@)((";
   var len = _.keys(self.config.alias_maps).length;
   console.log(len);
    var helpTxt = "The following aliases are supported: \n";
@@ -44,7 +44,7 @@ Bot.prototype.run = function () {
     helpTxt += key + "\n\t[" + value.join(", ") + "]\n ";
   });
 
-  pattern += self.config.helpName + "))";
+  pattern += self.config.helpName + "))(?!`)";
   helpTxt += self.config.helpName;
   if (verbose) {
     console.log("Pattern is: " + pattern);


### PR DESCRIPTION
Prevent matching mentions within quotes or code snippets. For ease of implementation, the regex searches for  `only after the mention, instead of trying to match it after and before, this mean "`@abc `" will match.
